### PR TITLE
Fixed issue with sausage.reset.css being invalid (search & replace error)

### DIFF
--- a/vendor/assets/stylesheets/sausage/sausage.reset.css
+++ b/vendor/assets/stylesheets/sausage/sausage.reset.css
@@ -14,7 +14,7 @@ http://developer.yahoo.com/yui/license.html
 version: 3.3.0
 build: 3167
 */
-.sausage-set {font:13px/1.231 'Hevetica Neueu', Helvetica, Arial, sans-serif;*font-size:small;*font:x-small;} .sausage-set select, .sausage-set input, .sausage-set button, .sausage-set textarea{font:99% "lucida grande", .sausage-set tahoma, .sausage-set verdana, .sausage-set arial, .sausage-set sans-serif;} .sausage-set table{font-size:inherit;font:100%;} .sausage-set pre, .sausage-set code, .sausage-set kbd, .sausage-set samp, .sausage-set tt{font-family:monospace;*font-size:108%;line-height:100%;}
+.sausage-set {font:13px/1.231 'Hevetica Neueu', Helvetica, Arial, sans-serif;*font-size:small;*font:x-small;} .sausage-set select, .sausage-set input, .sausage-set button, .sausage-set textarea{font:99% "lucida grande", tahoma, verdana, arial, sans-serif;} .sausage-set table{font-size:inherit;font:100%;} .sausage-set pre, .sausage-set code, .sausage-set kbd, .sausage-set samp, .sausage-set tt{font-family:monospace;*font-size:108%;line-height:100%;}
 
 /*
 Copyright (c) 2010, .reset  Yahoo! Inc. All rights reserved.
@@ -32,4 +32,4 @@ http://developer.yahoo.com/yui/license.html
 version: 3.3.0
 build: 3167
 */
-.reset {font:13px/1.231 Georgia, sans-serif;*font-size:small;*font:x-small;} .reset select, .reset input, .reset button, .reset textarea{font:99% "lucida grande", .reset tahoma, .reset verdana, .reset arial, .reset sans-serif;} .reset table{font-size:inherit;font:100%;} .reset pre, .reset code, .reset kbd, .reset samp, .reset tt{font-family:monospace;*font-size:108%;line-height:100%;}
+.reset {font:13px/1.231 Georgia, sans-serif;*font-size:small;*font:x-small;} .reset select, .reset input, .reset button, .reset textarea{font:99% "lucida grande", tahoma, verdana, arial, sans-serif;} .reset table{font-size:inherit;font:100%;} .reset pre, .reset code, .reset kbd, .reset samp, .reset tt{font-family:monospace;*font-size:108%;line-height:100%;}


### PR DESCRIPTION
I'm guessing a search and replace was carried out on the sausage.reset.css file which, unfortunately, led to an issue with the files validity:

```
.sausage-set textarea{font:99% "lucida grande", .sausage-set tahoma, .sausage-set verdana, .sausage-set arial, .sausage-set sans-serif;} 
```

The font names are prefixed with `.sausage-set`, which I guess happened when a search and replace was carried out on  `,` to add the prefix to the css rules.

This pull request fixes those issues.
